### PR TITLE
Fix Typo

### DIFF
--- a/src/main/resources/assets/rftoolsdim/lang/en_us.json
+++ b/src/main/resources/assets/rftoolsdim/lang/en_us.json
@@ -1,6 +1,6 @@
 {
   "block.rftoolsdim.dimlet_workbench": "Dimlet Workbench",
-  "block.rftoolsdim.knowledge_holder": "Knowlege Holder",
+  "block.rftoolsdim.knowledge_holder": "Knowledge Holder",
   "block.rftoolsdim.dimension_builder": "Dimension Builder",
   "block.rftoolsdim.enscriber": "Enscriber",
   "block.rftoolsdim.block_absorber": "Block Absorber",


### PR DESCRIPTION
Fixed Typo at line -3: "Knowlege" to "Knowledge".
I know it's just a little line, but it annoyed me while playing.
There's also missing a space in the Items description of "Syringe", but this item is not part of this mod-repo so i couldn't change it here