### PR TITLE
Dimlet Package for Emendatus Enigmatica

### DIFF
--- a/src/main/resources/data/rftoolsdim/dimletpackages/emendatusenigmatica.json
+++ b/src/main/resources/data/rftoolsdim/dimletpackages/emendatusenigmatica.json
@@ -1,0 +1,9812 @@
+[
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:aluminum_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:apatite_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:arcane_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bitumen_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:brass_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:bronze_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:certus_quartz_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:charged_certus_quartz_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cinnabar_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coal_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:cobalt_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:coke_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:constantan_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:copper_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_andesite_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_basalt_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_diorite_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_granite_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_gravel_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_jasper_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_marble_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_sand_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_scoria_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_slate_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_violecite_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:diamond_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 5000,
+        "maintain": 5000,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:dimensional_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:electrum_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:emerald_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:enderium_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluix_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:fluorite_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:gold_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:invar_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:iron_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lapis_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lead_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:lumium_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_aluminum",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_ancient_debris",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_apatite",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_arcane",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_bitumen",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_brass",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_bronze",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_certus_quartz",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_charged_certus_quartz",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_cinnabar",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_cloggrum",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_coal",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_cobalt",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_constantan",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_copper",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_diamond",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_dimensional",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_electrum",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_emerald",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_enderium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_fluix",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_fluorite",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_froststeel",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_gold",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_iesnium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_invar",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_iron",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_lapis",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_lead",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_lumium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_nebu",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_nickel",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_osmium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_potassium_nitrate",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_quartz",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_redstone",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_regalium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_signalum",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_silver",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_steel",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_sulfur",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_thallasium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_tin",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_uranium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_utherium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:molten_zinc",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:nickel_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:osmium_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:potassium_nitrate_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:quartz_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:redstone_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:signalum_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:silver_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:steel_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:sulfur_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:tin_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:uranium_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_andesite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_basalt_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_blackstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_block",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_blue_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_brimstone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_c_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_cryptic_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_diorite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_end_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_ether_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_flavolite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_gabbro_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_granite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_gravel_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_jasper_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_mossy_stone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_netherrack_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_nylium_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_raw_marble_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_sand_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_scoria_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_slate_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_soul_soil_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_subzero_ash_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_sulphuric_rock_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_violecite_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "block",
+        "key": "emendatusenigmatica:zinc_weathered_limestone_ore",
+        "rarity": "uncommon",
+        "create": 1500,
+        "maintain": 1500,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_aluminum",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_aluminum_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_ancient_debris",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_ancient_debris_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_apatite",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_apatite_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_arcane",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_arcane_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_bitumen",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_bitumen_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_brass",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_brass_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_bronze",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_bronze_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_certus_quartz",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_certus_quartz_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_charged_certus_quartz",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_charged_certus_quartz_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_cinnabar",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_cinnabar_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_cloggrum",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_cloggrum_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_coal",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_coal_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_cobalt",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_cobalt_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_constantan",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_constantan_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_copper",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_copper_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_diamond",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_diamond_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_dimensional",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_dimensional_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_electrum",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_electrum_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_emerald",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_emerald_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_enderium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_enderium_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_fluix",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_fluix_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_fluorite",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_fluorite_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_froststeel",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_froststeel_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_gold",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_gold_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_iesnium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_iesnium_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_invar",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_invar_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_iron",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_iron_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_lapis",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_lapis_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_lead",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_lead_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_lumium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_lumium_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_nebu",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_nebu_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_nickel",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_nickel_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_osmium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_osmium_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_potassium_nitrate",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_potassium_nitrate_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_quartz",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_quartz_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_redstone",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_redstone_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_regalium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_regalium_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_signalum",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_signalum_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_silver",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_silver_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_steel",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_steel_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_sulfur",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_sulfur_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_thallasium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_thallasium_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_tin",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_tin_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_uranium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_uranium_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_utherium",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_utherium_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_zinc",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    },
+    {
+        "type": "fluid",
+        "key": "emendatusenigmatica:molten_zinc_flowing",
+        "rarity": "common",
+        "create": 100,
+        "maintain": 100,
+        "ticks": 100,
+        "worldgen": true,
+        "dimlet": true
+    }
+]


### PR DESCRIPTION
This PR adds Dimlet Package support for the mod [Emendatus Enigmatica](https://www.curseforge.com/minecraft/mc-mods/emendatus-enigmatica)

Fluids are set to 100, the vast majority of blocks 1500, and diamond ore is set to 5000.

I set these a bit higher than other dimlet packages, because the vast majority of blocks here are useful resources.